### PR TITLE
Remove EL6 and information about requests for multiple OS versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,15 +19,9 @@ specific feature that is only available in newer versions of the software.  A
 bad reason would be to [pass a security audit][pci], because Red Hat actively
 [backports security fixes][backporting] to their stock packages.
 
-- What version of RHEL/CentOS would you like to use it on?  Note that we are no
-longer accepting requests for RHEL/CentOS 5.
-
 - Do you agree to test the new package to ensure that it works as expected?  We
 don't have any minimum requirements for testing, so use your best judgement and
-be as thorough as you feel is appropriate.  We do ask that if we build the
-package for multiple versions of RHEL/CentOS that you try to test all the
-versions.  Some issues may not be present on all OS versions due to differences
-in libraries and init systems.
+be as thorough as you feel is appropriate.
 
 [issues]: https://github.com/iuscommunity/wishlist/issues?q=is%3Aissue
 [iuscommunity-pkg]: https://github.com/iuscommunity-pkg

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -5,11 +5,7 @@ foobar 2.0.x
 ### Why?
 
 In foobar 2.0.0, the --whiz-bang flag was added.  This feature would be very
-useful to me.  RHEL 6 only has foobar 1.7.8, and RHEL 7 only has foobar 1.8.1.
-
-### OS versions
-
-I would like this package for both RHEL 6 and 7.
+useful to me, and RHEL 7 only has foobar 1.8.1.
 
 ### Testing
 


### PR DESCRIPTION
Remove EL6 and information about requests for multiple OS versions. We only are only taking new package requests for El7, see iuscommunity/announce#5.