### PR TITLE
STABLE for stable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,9 @@ bad reason would be to [pass a security audit][pci], because Red Hat actively
 
 - Do you agree to test the new package to ensure that it works as expected?  We
 don't have any minimum requirements for testing, so use your best judgement and
-be as thorough as you feel is appropriate.
+be as thorough as you feel is appropriate.  Once you feel the package is ready
+and would like to see it promoted to the stable repos, comment on the issue
+with the word "STABLE".
 
 [issues]: https://github.com/iuscommunity/wishlist/issues?q=is%3Aissue
 [iuscommunity-pkg]: https://github.com/iuscommunity-pkg

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -9,4 +9,6 @@ useful to me, and RHEL 7 only has foobar 1.8.1.
 
 ### Testing
 
-I agree to test the new package to ensure that it works as expected.
+I agree to test the new package to ensure that it works as expected.  Once I am
+satisfied with the results of my testing I will comment on this issue with the
+word "STABLE" to get it promoted to the stable repos.


### PR DESCRIPTION
We regularly see users reply with uncertain wording about their testing.  Update the docs to indicate that we want a clear, decisive response about pushing to stable.